### PR TITLE
Explicit UTC timezone to make DateTime consistency

### DIFF
--- a/src/main/java/com/howtank/streams/client/StreamClientHttp.java
+++ b/src/main/java/com/howtank/streams/client/StreamClientHttp.java
@@ -53,7 +53,9 @@ public class StreamClientHttp implements StreamClient {
         ObjectMapper objectMapper = new ObjectMapper();
         objectMapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
         objectMapper.configure(DeserializationFeature.READ_UNKNOWN_ENUM_VALUES_AS_NULL, false);
-        objectMapper.setDateFormat(DateFormat.getDateTimeInstance(DateFormat.DEFAULT, DateFormat.DEFAULT));
+        DateFormat dateFormat = DateFormat.getDateTimeInstance(DateFormat.DEFAULT, DateFormat.DEFAULT);
+        dateFormat.setTimeZone(TimeZone.getTimeZone("UTC"));
+        objectMapper.setDateFormat(dateFormat);
         return objectMapper;
     }
 

--- a/src/main/java/com/howtank/streams/client/api/response/GetPresenceApiResponse.java
+++ b/src/main/java/com/howtank/streams/client/api/response/GetPresenceApiResponse.java
@@ -3,19 +3,11 @@ package com.howtank.streams.client.api.response;
 import com.fasterxml.jackson.annotation.JsonAlias;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.core.JacksonException;
-import com.fasterxml.jackson.core.JsonParser;
-import com.fasterxml.jackson.databind.DeserializationContext;
-import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
-import com.fasterxml.jackson.databind.deser.std.StdDeserializer;
 import com.howtank.streams.model.Presence;
 import com.howtank.streams.model.User;
 import com.howtank.streams.model.types.ConnectionStatusType;
 import lombok.Data;
 
-import java.io.IOException;
-import java.text.ParseException;
-import java.text.SimpleDateFormat;
 import java.util.Date;
 import java.util.List;
 import java.util.Set;
@@ -38,7 +30,6 @@ public class GetPresenceApiResponse extends ApiResponse {
 @Data
 class PresenceDto {
     @JsonProperty("connection_date")
-    @JsonDeserialize(using = ConnectionDateDeserializer.class)
     private Date connectionDate;
 
     @JsonProperty("connection_status")
@@ -87,26 +78,5 @@ class PresenceDto {
                         .type(userType)
                         .build())
                 .build();
-    }
-}
-
-class ConnectionDateDeserializer extends StdDeserializer<Date> {
-    public ConnectionDateDeserializer() {
-        this(null);
-    }
-
-    private ConnectionDateDeserializer(Class<?> vc) {
-        super(vc);
-    }
-
-    @Override
-    public Date deserialize(JsonParser jsonParser, DeserializationContext deserializationContext) throws IOException {
-        SimpleDateFormat formatter = new SimpleDateFormat("MMM dd, yyyy HH:mm:ss aa");
-        String date = jsonParser.getText();
-        try {
-            return formatter.parse(date);
-        } catch (ParseException e) {
-            throw new RuntimeException(e);
-        }
     }
 }

--- a/src/test/java/com/howtank/streams/client/StreamClientHttpTest.java
+++ b/src/test/java/com/howtank/streams/client/StreamClientHttpTest.java
@@ -217,7 +217,7 @@ public class StreamClientHttpTest {
         Presence presence = presences.get(0);
         Assertions.assertEquals("1231131312dwqw", presence.getUser().getId());
         Assertions.assertEquals("ADMIN", presence.getUser().getDisplayName());
-        Assertions.assertEquals(1661304051000L, presence.getConnectionDate().getTime());
+        Assertions.assertEquals(1661329251000L, presence.getConnectionDate().getTime());
         Assertions.assertEquals(0L, presence.getUser().getPoints());
     }
 


### PR DESCRIPTION
issue: difference in timestamp between machines.

Without defining an explicit timezone, Jackson will use the local timezone. That causes the issue of difference in timestamp between machines.

Changes:
 - revert the last commit
 - defining an explicit timezone (UTC)